### PR TITLE
Allow non-boolean errand state values

### DIFF
--- a/om/applychanges.go
+++ b/om/applychanges.go
@@ -16,7 +16,7 @@ import (
 )
 
 type errandConfig struct {
-	RunPostDeploy map[string]bool `json:"run_post_deploy"`
+	RunPostDeploy map[string]interface{} `json:"run_post_deploy"`
 }
 
 type applyChangesRequest struct {
@@ -231,8 +231,8 @@ func (a *API) streamLog(output io.Writer) error {
 func (a *API) getErrandConfig(guid string) (errandConfig, error) {
 	errandBody := struct {
 		Errands []struct {
-			Name       string `json:"name"`
-			PostDeploy *bool  `json:"post_deploy,omitempty"`
+			Name       string      `json:"name"`
+			PostDeploy interface{} `json:"post_deploy,omitempty"`
 		} `json:"errands"`
 	}{}
 
@@ -262,7 +262,7 @@ func (a *API) getErrandConfig(guid string) (errandConfig, error) {
 		return errandConfig{}, err
 	}
 
-	errandMap := map[string]bool{}
+	errandMap := map[string]interface{}{}
 	for _, errand := range errandBody.Errands {
 		if errand.PostDeploy != nil {
 			errandMap[errand.Name] = false

--- a/om/applychanges_test.go
+++ b/om/applychanges_test.go
@@ -245,7 +245,7 @@ func errandConfigHandler(w http.ResponseWriter, r *http.Request) {
 	"errands": [
 	{
 		"name": "errand-1",
-		"post_deploy": false,
+		"post_deploy": "when-changed",
 		"label": "Errand 1 Label"
 	},
 	{


### PR DESCRIPTION
Errand states can be `true`, `false`, `"default"`, and `"when-changed"`.
This commit will remove the requirement that those fields be pure
booleans, but still allow them to avoid JSON quoting of `true` and
`false`.